### PR TITLE
feat: bump gcc to 8.3.0

### DIFF
--- a/core/gcc-cross.sh
+++ b/core/gcc-cross.sh
@@ -1,7 +1,7 @@
-download https://ftp.gnu.org/gnu/mpfr/mpfr-4.0.1.tar.xz mpfr
+download https://ftp.gnu.org/gnu/mpfr/mpfr-4.0.2.tar.xz mpfr
 download https://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.xz gmp
 download https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz mpc
-download https://ftp.gnu.org/gnu/gcc/gcc-7.4.0/gcc-7.4.0.tar.xz
+download https://ftp.gnu.org/gnu/gcc/gcc-8.3.0/gcc-8.3.0.tar.xz
 
 for file in ../gcc/config/{linux,i386/linux{,64}}.h; do
   cp -uv $file{,.orig}

--- a/core/gcc-native.sh
+++ b/core/gcc-native.sh
@@ -1,9 +1,9 @@
 exportcross
 
-download https://ftp.gnu.org/gnu/mpfr/mpfr-4.0.1.tar.xz mpfr
+download https://ftp.gnu.org/gnu/mpfr/mpfr-4.0.2.tar.xz mpfr
 download https://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.xz gmp
 download https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz mpc
-download https://ftp.gnu.org/gnu/gcc/gcc-7.4.0/gcc-7.4.0.tar.xz
+download https://ftp.gnu.org/gnu/gcc/gcc-8.3.0/gcc-8.3.0.tar.xz
 
 cat ../gcc/limitx.h ../gcc/glimits.h ../gcc/limity.h > `dirname $(${TARGET}-gcc -print-libgcc-file-name)`/include-fixed/limits.h
 

--- a/core/libstdc++.sh
+++ b/core/libstdc++.sh
@@ -1,13 +1,13 @@
 exportcross
 
-download https://ftp.gnu.org/gnu/gcc/gcc-7.4.0/gcc-7.4.0.tar.xz
+download https://ftp.gnu.org/gnu/gcc/gcc-8.3.0/gcc-8.3.0.tar.xz
 
 ../libstdc++-v3/configure \
     --build=${HOST} \
     --host=${TARGET} \
     --target=${TARGET} \
     --prefix=${TOOLCHAIN} \
-    --with-gxx-include-dir=${TOOLCHAIN}/${TARGET}/include/c++/7.4.0 \
+    --with-gxx-include-dir=${TOOLCHAIN}/${TARGET}/include/c++/8.3.0 \
     --disable-multilib \
     --disable-nls \
     --disable-libstdcxx-threads \


### PR DESCRIPTION
fixes: #4

Set of versions matches Debian package for gcc-8.3.0

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>