### PR TITLE
feat: build Go as part of toolchain image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,13 @@ extras:
 		--target=$@ \
 		-f ./Dockerfile .
 
+.PHONY: golang
+golang:
+	@docker build \
+		-t autonomy/$@:$(SHA) \
+		--target=$@ \
+		-f ./Dockerfile .
+
 .PHONY: toolchain
 toolchain:
 	@docker build \

--- a/golang/go.sh
+++ b/golang/go.sh
@@ -1,0 +1,45 @@
+# build bootstrap Go 1.4 which doesn't depend on Go to build itself
+
+mkdir -p go1.4-boostrap/build
+cd go1.4-boostrap/build
+
+download https://dl.google.com/go/go1.4-bootstrap-20171003.tar.gz
+
+cd ../src
+
+sh make.bash
+
+cd ..
+
+export GOROOT_BOOTSTRAP="$PWD"
+
+cd ..
+
+# build desired Go version using bootstrap Go 1.4
+
+mkdir -p go/build
+cd go/build
+
+download https://dl.google.com/go/go${GOLANG_VERSION}.src.tar.gz
+
+cd ../src
+
+export GOROOT_FINAL="$TOOLCHAIN/go"
+
+sh make.bash
+
+cd ..
+
+# cleanup a bit
+rm -rf pkg/obj
+rm -rf pkg/bootstrap
+rm -f pkg/tool/*/api
+find src \( -type f -a -name "*_test.go" \) \
+		-exec rm -rf \{\} \+
+	find src \( -type d -a -name "testdata" \) \
+		-exec rm -rf \{\} \+
+	find src -type f -a \( -name "*.bash" -o -name "*.rc" -o -name "*.bat" \) \
+		-exec rm -rf \{\} \+
+
+mkdir -p "$GOROOT_FINAL"
+mv * "$GOROOT_FINAL"


### PR DESCRIPTION
First, last version of Go which doesn't require to build itself is
bootstrapped (Go 1.4). With that bootstrap compiler, Go of desired
version is built.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>